### PR TITLE
feat: implement hookability with the on() statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $wpUtilService = new WpUtilService($wpService);
 
 ### Enqueue Scripts
 - `enqueue()` returns an `EnqueueManager`.
+- `on()` wraps the folling functions inside a hook (eg. wp_enqueue_script). Only documented hooks are allowed. 
 - `add()` enqueues a script.
 - `with()` may be chained with data or translation functions. 
 - `and()` is a synonym to `with()` but cannot be called before `with()`.
@@ -50,6 +51,7 @@ $wpUtilService = new WpUtilService($wpService);
 ```php
 $wpUtilService
     ->enqueue(__DIR__)
+    ->on('wp_enqueue_script', 20)
     ->add('main.js', ['jquery'])
     ->with()->translation(
         'objectName',

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $wpUtilService = new WpUtilService($wpService);
 ```php
 $wpUtilService
     ->enqueue(__DIR__)
-    ->on('wp_enqueue_script', 20)
+    ->on('wp_enqueue_scripts', 20)
     ->add('main.js', ['jquery'])
     ->with()->translation(
         'objectName',

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $wpUtilService = new WpUtilService($wpService);
 
 ### Enqueue Scripts
 - `enqueue()` returns an `EnqueueManager`.
-- `on()` wraps the folling functions inside a hook (eg. wp_enqueue_script). Only documented hooks are allowed. 
+- `on()` wraps the following functions inside a hook (eg. wp_enqueue_script). Only documented hooks are allowed. 
 - `add()` enqueues a script.
 - `with()` may be chained with data or translation functions. 
 - `and()` is a synonym to `with()` but cannot be called before `with()`.

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "fix": "vendor/bin/mago lint --format-after-fix --fix",
         "format": "vendor/bin/mago fmt",
         "stan": "php -d memory_limit=512M vendor/bin/phpstan analyse --configuration=phpstan.neon",
-        "test:watch": "bash -c \"find tests -type f -name '*.php' | entr -c sh -c './vendor/bin/phpunit --testdox --no-coverage'\""
+        "test:watch": "bash -c \"find src tests -type f -name '*.php' | entr -c sh -c './vendor/bin/phpunit --testdox --no-coverage'\""
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "lint": "vendor/bin/mago lint",
         "fix": "vendor/bin/mago lint --format-after-fix --fix",
         "format": "vendor/bin/mago fmt",
-        "stan": "php -d memory_limit=512M vendor/bin/phpstan analyse --configuration=phpstan.neon"
+        "stan": "php -d memory_limit=512M vendor/bin/phpstan analyse --configuration=phpstan.neon",
+        "test:watch": "bash -c \"find tests -type f -name '*.php' | entr -c sh -c './vendor/bin/phpunit --testdox --no-coverage'\""
     },
     "config": {
         "allow-plugins": {

--- a/src/Features/Enqueue/AssetRegistrar.php
+++ b/src/Features/Enqueue/AssetRegistrar.php
@@ -17,6 +17,11 @@ class AssetRegistrar
     private null|string $enqueueHook = null;
 
     /**
+     * @var enqueuePriority The priority for the enqueue hook.
+     */
+    private int $enqueuePriority = 10;
+
+    /**
      * Constructor.
      *
      * @param WpService $wpService
@@ -39,9 +44,13 @@ class AssetRegistrar
         $wrapWithAction = function (callable $fn) {
             if ($this->enqueueHook !== null) {
                 return function (...$args) use ($fn) {
-                    $this->wpService->addAction($this->enqueueHook, function () use ($fn, $args) {
-                        $fn(...$args);
-                    });
+                    $this->wpService->addAction(
+                        $this->enqueueHook,
+                        function () use ($fn, $args) {
+                            $fn(...$args);
+                        },
+                        $this->enqueuePriority,
+                    );
                 };
             }
             return $fn;
@@ -129,7 +138,7 @@ class AssetRegistrar
      *
      * @throws \InvalidArgumentException
      */
-    public function setEnqueueHook(string $hook): void
+    public function setEnqueueHook(string $hook, int $priority = 10): void
     {
         if ($hook === '') {
             throw new \InvalidArgumentException('Enqueue hook cannot be empty.');
@@ -153,5 +162,6 @@ class AssetRegistrar
         }
 
         $this->enqueueHook = $hook;
+        $this->enqueuePriority = $priority;
     }
 }

--- a/src/Features/Enqueue/AssetRegistrar.php
+++ b/src/Features/Enqueue/AssetRegistrar.php
@@ -135,6 +135,7 @@ class AssetRegistrar
      * Set the hook on which to enqueue assets.
      *
      * @param string $hook
+     * @param int $priority The priority for the hook (default: 10)
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Features/Enqueue/AssetRegistrar.php
+++ b/src/Features/Enqueue/AssetRegistrar.php
@@ -12,6 +12,11 @@ use WpService\WpService;
 class AssetRegistrar
 {
     /**
+     * @var enqueueHook The hook on which to enqueue assets.
+     */
+    private null|string $enqueueHook = null;
+
+    /**
      * Constructor.
      *
      * @param WpService $wpService
@@ -30,38 +35,41 @@ class AssetRegistrar
      */
     public function getRegisterEnqueueFunctions(string $type): array
     {
+        // Wrap functions to optionally hook into WordPress actions
+        $wrapWithAction = function (callable $fn) {
+            if ($this->enqueueHook !== null) {
+                return function (...$args) use ($fn) {
+                    $this->wpService->addAction($this->enqueueHook, function () use ($fn, $args) {
+                        $fn(...$args);
+                    });
+                };
+            }
+            return $fn;
+        };
+
         if ($type === 'js') {
             return [
-                'register' => fn($handle, $src, $deps) => $this->wpService->wpRegisterScript(
-                    $handle,
-                    $src,
-                    $deps,
-                    false,
-                    true,
+                'register' => $wrapWithAction(
+                    fn($handle, $src, $deps) => $this->wpService->wpRegisterScript($handle, $src, $deps, false, true),
                 ),
-                'enqueue' => fn($handle) => $this->wpService->wpEnqueueScript($handle),
-                'localize' => fn($handle, $objectName, $data) => $this->wpService->wpLocalizeScript(
-                    $handle,
-                    $objectName,
-                    $data,
+                'enqueue' => $wrapWithAction(fn($handle) => $this->wpService->wpEnqueueScript($handle)),
+                'localize' => $wrapWithAction(
+                    fn($handle, $objectName, $data) => $this->wpService->wpLocalizeScript($handle, $objectName, $data),
                 ),
-                'data' => fn($handle, $objectName, $data) => $this->wpService->wpAddInlineScript(
+                'data' => $wrapWithAction(fn($handle, $objectName, $data) => $this->wpService->wpAddInlineScript(
                     $handle,
                     'var ' . $objectName . ' = ' . wp_json_encode($data) . ';',
                     'before',
-                ),
+                )),
             ];
         }
 
         if ($type === 'css') {
             return [
-                'register' => fn($handle, $src, $deps) => $this->wpService->wpRegisterStyle(
-                    $handle,
-                    $src,
-                    $deps,
-                    false,
+                'register' => $wrapWithAction(
+                    fn($handle, $src, $deps) => $this->wpService->wpRegisterStyle($handle, $src, $deps, false),
                 ),
-                'enqueue' => fn($handle) => $this->wpService->wpEnqueueStyle($handle),
+                'enqueue' => $wrapWithAction(fn($handle) => $this->wpService->wpEnqueueStyle($handle)),
             ];
         }
 
@@ -112,5 +120,38 @@ class AssetRegistrar
 
         // Throw an exception if the type cannot be determined
         throw new \InvalidArgumentException("Cannot determine asset type for handle: {$handle}");
+    }
+
+    /**
+     * Set the hook on which to enqueue assets.
+     *
+     * @param string $hook
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setEnqueueHook(string $hook): void
+    {
+        if ($hook === '') {
+            throw new \InvalidArgumentException('Enqueue hook cannot be empty.');
+        }
+
+        $allowed = [
+            'wp_enqueue_scripts',
+            'admin_enqueue_scripts',
+            'login_enqueue_scripts',
+            'enqueue_block_assets',
+            'enqueue_block_editor_assets',
+        ];
+
+        $isAllowed =
+            in_array($hook, $allowed, true)
+            || str_starts_with($hook, 'admin_print_scripts-')
+            || str_starts_with($hook, 'admin_print_styles-');
+
+        if (!$isAllowed) {
+            throw new \InvalidArgumentException("Invalid enqueue hook: {$hook}");
+        }
+
+        $this->enqueueHook = $hook;
     }
 }

--- a/src/Features/Enqueue/AssetRegistrar.php
+++ b/src/Features/Enqueue/AssetRegistrar.php
@@ -67,7 +67,7 @@ class AssetRegistrar
                 ),
                 'data' => $wrapWithAction(fn($handle, $objectName, $data) => $this->wpService->wpAddInlineScript(
                     $handle,
-                    'var ' . $objectName . ' = ' . wp_json_encode($data) . ';',
+                    'var ' . $objectName . ' = ' . $this->wpService->wpJsonEncode($data) . ';',
                     'before',
                 )),
             ];

--- a/src/Features/Enqueue/AssetRegistrar.php
+++ b/src/Features/Enqueue/AssetRegistrar.php
@@ -140,10 +140,6 @@ class AssetRegistrar
      */
     public function setEnqueueHook(string $hook, int $priority = 10): void
     {
-        if ($hook === '') {
-            throw new \InvalidArgumentException('Enqueue hook cannot be empty.');
-        }
-
         $allowed = [
             'wp_enqueue_scripts',
             'admin_enqueue_scripts',
@@ -158,7 +154,7 @@ class AssetRegistrar
             || str_starts_with($hook, 'admin_print_styles-');
 
         if (!$isAllowed) {
-            throw new \InvalidArgumentException("Invalid enqueue hook: {$hook}");
+            throw new \InvalidArgumentException("Invalid enqueue hook: {($hook ?: 'EMPTY_HOOK_NAME')}");
         }
 
         $this->enqueueHook = $hook;

--- a/src/Features/Enqueue/AssetRegistrar.php
+++ b/src/Features/Enqueue/AssetRegistrar.php
@@ -17,7 +17,7 @@ class AssetRegistrar
     private null|string $enqueueHook = null;
 
     /**
-     * @var enqueuePriority The priority for the enqueue hook.
+     * @var int $enqueuePriority The priority for the enqueue hook.
      */
     private int $enqueuePriority = 10;
 

--- a/src/Features/Enqueue/AssetUrlResolver.php
+++ b/src/Features/Enqueue/AssetUrlResolver.php
@@ -42,7 +42,7 @@ class AssetUrlResolver
      */
     public function getDistDirectory(): null|string
     {
-        return rtrim($this->assetsDistPath, '/') . '/';
+        return rtrim($this->assetsDistPath ?? '', '/') . '/';
     }
 
     /**

--- a/src/Features/Enqueue/AssetUrlResolver.php
+++ b/src/Features/Enqueue/AssetUrlResolver.php
@@ -31,6 +31,8 @@ class AssetUrlResolver
 
     /**
      * Set the dist directory.
+     *
+     * @param string $distDirectory Dist directory path
      */
     public function setDistDirectory(string $distDirectory): void
     {
@@ -39,6 +41,8 @@ class AssetUrlResolver
 
     /**
      * Get the dist directory.
+     *
+     * @return string|null
      */
     public function getDistDirectory(): null|string
     {
@@ -47,6 +51,11 @@ class AssetUrlResolver
 
     /**
      * Resolve full asset URL (with cache-busting if available).
+     *
+     * @param string $src Relative asset path
+     * @param RuntimeContextEnum|null $contextMode Context mode for URL resolution
+     * @param string|null $rootDirectory Root directory for plugin/MU-plugin contexts
+     * @return string
      */
     public function getAssetUrl(
         string $src,
@@ -89,6 +98,12 @@ class AssetUrlResolver
 
     /**
      * MU-Plugin dir URL resolver.
+     *
+     * @param string $src Relative asset path
+     *
+     * @param string|null $rootDirectory Root directory for MU-plugin context
+     * @throws \RuntimeException
+     * @return string
      */
     private function muPluginDirUrl(string $src, null|string $rootDirectory = null): string
     {
@@ -98,6 +113,9 @@ class AssetUrlResolver
 
     /**
      * Determine if a script is a module by checking manifest (if available).
+     *
+     * @param string $src Relative asset path
+     * @return bool
      */
     public function isModule(string $src): bool
     {

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -90,6 +90,10 @@ class EnqueueManager implements EnqueueManagerInterface
 
     /**
      * Set the hook on which to enqueue assets.
+     *
+     * @param string $hook The WordPress hook name
+     * @param int $priority The priority for the hook (default: 10)
+     * @return self
      */
     public function setEnqueueHook(string $hook, int $priority = 10): self
     {
@@ -99,6 +103,9 @@ class EnqueueManager implements EnqueueManagerInterface
 
     /**
      * Set the dist directory and return this instance (fluent).
+     *
+     * @param string $distDirectory
+     * @return self
      */
     public function setDistDirectory(string $distDirectory): self
     {
@@ -110,6 +117,9 @@ class EnqueueManager implements EnqueueManagerInterface
 
     /**
      * Set the context mode and return this instance (fluent).
+     *
+     * @param RuntimeContextEnum|null $contextMode
+     * @return self
      */
     public function setContextMode(null|RuntimeContextEnum $contextMode): self
     {
@@ -117,6 +127,12 @@ class EnqueueManager implements EnqueueManagerInterface
         return $this;
     }
 
+    /**
+     * Set the root directory and return this instance (fluent).
+     *
+     * @param string|null $rootDirectory
+     * @return self
+     */
     public function setRootDirectory(null|string $rootDirectory): self
     {
         $this->config['rootDirectory'] = $rootDirectory;

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -188,7 +188,11 @@ class EnqueueManager implements EnqueueManagerInterface
     }
 
     /**
-     * What hook to attach to when rendering assets.
+     * Set the hook on which to attach when rendering assets.
+     *
+     * @param string $hook The WordPress hook name
+     * @param int $priority The priority for the hook (default: 10)
+     * @return EnqueueManager A cloned instance with the hook configured
      */
     public function on(string $hook, int $priority = 10): EnqueueManager
     {

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -88,6 +88,12 @@ class EnqueueManager implements EnqueueManagerInterface
         return $this;
     }
 
+    public function setEnqueueHook(string $hook): self
+    {
+        $this->assetRegistrar->setEnqueueHook($hook);
+        return $this;
+    }
+
     /**
      * Set the dist directory and return this instance (fluent).
      */
@@ -176,6 +182,18 @@ class EnqueueManager implements EnqueueManagerInterface
         $this->with($function, ...$args);
 
         return $this->with();
+    }
+
+    /**
+     * What hook to attach to when rendering assets.
+     */
+    public function on(string $hook): EnqueueManager
+    {
+        if ($this->lastHandle !== null) {
+            throw new \RuntimeException('The on() method must be called before adding any assets with add().');
+        }
+        $this->assetRegistrar->setEnqueueHook($hook);
+        return $this;
     }
 
     /**

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -37,7 +37,7 @@ class EnqueueManager implements EnqueueManagerInterface
     /**
      * @var AssetRegistrar
      */
-    private AssetRegistrar $assetRegistrar;
+    public AssetRegistrar $assetRegistrar;
 
     /**
      * @var AssetLocalization
@@ -192,12 +192,10 @@ class EnqueueManager implements EnqueueManagerInterface
      */
     public function on(string $hook, int $priority = 10): EnqueueManager
     {
-        if ($this->lastHandle !== null) {
-            $this->lastHandle = null;
-            $this->handleHasSeenWithFunction = [];
-        }
-        $this->assetRegistrar->setEnqueueHook($hook, $priority);
-        return $this;
+        $clone = clone $this;
+        $clone->lastHandle = null;
+        $clone->assetRegistrar->setEnqueueHook($hook, $priority);
+        return $clone;
     }
 
     /**

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -88,9 +88,12 @@ class EnqueueManager implements EnqueueManagerInterface
         return $this;
     }
 
-    public function setEnqueueHook(string $hook): self
+    /**
+     * Set the hook on which to enqueue assets.
+     */
+    public function setEnqueueHook(string $hook, int $priority = 10): self
     {
-        $this->assetRegistrar->setEnqueueHook($hook);
+        $this->assetRegistrar->setEnqueueHook($hook, $priority);
         return $this;
     }
 
@@ -187,12 +190,12 @@ class EnqueueManager implements EnqueueManagerInterface
     /**
      * What hook to attach to when rendering assets.
      */
-    public function on(string $hook): EnqueueManager
+    public function on(string $hook, int $priority = 10): EnqueueManager
     {
         if ($this->lastHandle !== null) {
             throw new \RuntimeException('The on() method must be called before adding any assets with add().');
         }
-        $this->assetRegistrar->setEnqueueHook($hook);
+        $this->assetRegistrar->setEnqueueHook($hook, $priority);
         return $this;
     }
 

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -193,8 +193,8 @@ class EnqueueManager implements EnqueueManagerInterface
     public function on(string $hook, int $priority = 10): EnqueueManager
     {
         if ($this->lastHandle !== null) {
-            throw new \RuntimeException('The on() method must be called before adding any assets with add(). 
-                Already added: ' . $this->lastHandle);
+            $this->lastHandle = null;
+            $this->handleHasSeenWithFunction = [];
         }
         $this->assetRegistrar->setEnqueueHook($hook, $priority);
         return $this;

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -37,7 +37,7 @@ class EnqueueManager implements EnqueueManagerInterface
     /**
      * @var AssetRegistrar
      */
-    public AssetRegistrar $assetRegistrar;
+    private AssetRegistrar $assetRegistrar;
 
     /**
      * @var AssetLocalization

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -193,7 +193,8 @@ class EnqueueManager implements EnqueueManagerInterface
     public function on(string $hook, int $priority = 10): EnqueueManager
     {
         if ($this->lastHandle !== null) {
-            throw new \RuntimeException('The on() method must be called before adding any assets with add().');
+            throw new \RuntimeException('The on() method must be called before adding any assets with add(). 
+                Already added: ' . $this->lastHandle);
         }
         $this->assetRegistrar->setEnqueueHook($hook, $priority);
         return $this;
@@ -220,7 +221,7 @@ class EnqueueManager implements EnqueueManagerInterface
      * @param string|null $objectName
      * @param array $data
      *
-     * @throws \RuntimeException
+     * @throws \RuntimeExceptionrd
      */
     public function addDataToHandle(string $handle, null|string $objectName, array $data): void
     {

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -219,7 +219,7 @@ class EnqueueManager implements EnqueueManagerInterface
      * @param string|null $objectName
      * @param array $data
      *
-     * @throws \RuntimeExceptionrd
+     * @throws \RuntimeException
      */
     public function addDataToHandle(string $handle, null|string $objectName, array $data): void
     {

--- a/src/Features/Enqueue/EnqueueManager.php
+++ b/src/Features/Enqueue/EnqueueManager.php
@@ -294,4 +294,16 @@ class EnqueueManager implements EnqueueManagerInterface
         }
         return $handle;
     }
+
+    /**
+     * Clone support to ensure deep copies of internal objects.
+     */
+    public function __clone()
+    {
+        $this->assetRegistrar = clone $this->assetRegistrar;
+        $this->assetLocalization = clone $this->assetLocalization;
+        $this->assetData = clone $this->assetData;
+        $this->assetUrlResolver = clone $this->assetUrlResolver;
+        $this->scriptAttributeManager = clone $this->scriptAttributeManager;
+    }
 }

--- a/src/Traits/Enqueue.php
+++ b/src/Traits/Enqueue.php
@@ -22,8 +22,8 @@ trait Enqueue
      *       manifestName:  'manifest.json',
      *       cacheBust:     true
      *   )
-     *   ->on('wp_enqueue_scripts', 20)
      *   ->add('main.js', ['jquery'], '1.0.0', true)
+     *   ->on('wp_enqueue_scripts', 20)
      *   ->with()
      *       ->translation('objectName', [
      *           'localization_a' => ['Test']

--- a/src/Traits/Enqueue.php
+++ b/src/Traits/Enqueue.php
@@ -22,6 +22,7 @@ trait Enqueue
      *       manifestName:  'manifest.json',
      *       cacheBust:     true
      *   )
+     *   ->on('wp_enqueue_scripts', 20)
      *   ->add('main.js', ['jquery'], '1.0.0', true)
      *   ->with()
      *       ->translation('objectName', [

--- a/tests/EnqueueManagerTest.php
+++ b/tests/EnqueueManagerTest.php
@@ -128,7 +128,7 @@ class EnqueueManagerTest extends TestCase
         $manager->add('main.js', ['jquery'], '1.0.0', true)->on('somehook', 20);
     }
 
-    public function testHookIsAddedWhenUsingOnStatement()
+    public function testHookIsAddedWhenUsingOnStatementForJsAsset()
     {
         $wpService = $this->getWpService();
         $manager = new EnqueueManager($wpService);
@@ -144,7 +144,7 @@ class EnqueueManagerTest extends TestCase
             'localization_a' => ['Test'],
         ]);
 
-        // Check that only main.js is hooked
+        //Test that on() added the hook correctly
         $callLogAddAction = $wpService->getCallLog('addAction');
         $found = false;
         foreach ($callLogAddAction as $call) {
@@ -153,6 +153,32 @@ class EnqueueManagerTest extends TestCase
                 && is_object($call[1])
                 && $call[1] instanceof \Closure
                 && $call[2] === 20
+            ) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, 'The enqueueAssets hook was not added correctly.');
+    }
+
+    public function testHookIsAddedWhenUsingOnStatementForCssAsset()
+    {
+        $wpService = $this->getWpService();
+        $manager = new EnqueueManager($wpService);
+        $manager->setDistDirectory('/path/to/dist');
+
+        // First chain with on()
+        $manager->on('wp_enqueue_scripts', 30)->add('main.css');
+
+        //Test that on() added the hook correctly
+        $callLogAddAction = $wpService->getCallLog('addAction');
+        $found = false;
+        foreach ($callLogAddAction as $call) {
+            if (
+                $call[0] === 'wp_enqueue_scripts'
+                && is_object($call[1])
+                && $call[1] instanceof \Closure
+                && $call[2] === 30
             ) {
                 $found = true;
                 break;

--- a/tests/EnqueueManagerTest.php
+++ b/tests/EnqueueManagerTest.php
@@ -215,6 +215,26 @@ class EnqueueManagerTest extends TestCase
         }
     }
 
+    public function testAdminPrintScriptsHookIsAccepted()
+    {
+        $manager = new EnqueueManager($this->getWpService());
+        $manager->setDistDirectory('/path/to/dist');
+
+        // Should not throw
+        $result = $manager->on('admin_print_scripts-settings_page', 10);
+        $this->assertInstanceOf(EnqueueManager::class, $result);
+    }
+
+    public function testAdminPrintStylesHookIsAccepted()
+    {
+        $manager = new EnqueueManager($this->getWpService());
+        $manager->setDistDirectory('/path/to/dist');
+
+        // Should not throw
+        $result = $manager->on('admin_print_styles-settings_page', 10);
+        $this->assertInstanceOf(EnqueueManager::class, $result);
+    }
+
     public function testWithThrowsIfNoAssetAdded()
     {
         $manager = new EnqueueManager($this->getWpService());

--- a/tests/EnqueueManagerTest.php
+++ b/tests/EnqueueManagerTest.php
@@ -137,6 +137,29 @@ class EnqueueManagerTest extends TestCase
         $manager->add('main.js', ['jquery'], '1.0.0', true)->on('wp_enqueue_script', 20);
     }
 
+    public function testOnNotThowsWhenIsInSeparateChains()
+    {
+        $manager = new EnqueueManager($this->getWpService());
+        $manager->setDistDirectory('/path/to/dist');
+
+        // Second chain without on()
+        $manager->add('second.js', [], '1.0.0', true)->with()->data(null, [
+            'id' => 1,
+        ]);
+
+        // First chain with on()
+        $manager->on('wp_enqueue_scripts', 20)->add(
+            'main.js',
+            ['jquery'],
+            '1.0.0',
+            true,
+        )->with()->translation('objectName', [
+            'localization_a' => ['Test'],
+        ]);
+
+        $this->assertTrue(true);
+    }
+
     public function testWithThrowsIfNoAssetAdded()
     {
         $manager = new EnqueueManager($this->getWpService());

--- a/tests/EnqueueManagerTest.php
+++ b/tests/EnqueueManagerTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace WpUtilService\Tests;
 
 use PHPUnit\Framework\TestCase;
-use WpUtilService\Features\Enqueue\EnqueueManager;
 use WpUtilService\Features\Enqueue\EnqueueAssetContext;
+use WpUtilService\Features\Enqueue\EnqueueManager;
 use WpUtilService\Tests\FakeWpService;
 
 class EnqueueManagerTest extends TestCase
@@ -14,22 +14,20 @@ class EnqueueManagerTest extends TestCase
     public function testFluentApiChaining()
     {
         //Setup deps
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
         $manager->setDistDirectory('/path/to/dist');
 
         // Test chaining add and with()->translation
         $result = $manager
             ->add('main.js', ['jquery'], '1.0.0', true)
-              ->with()
-                ->translation('objectName', [
-                  'localization_a' => ['Test']
-                ])
-              ->and()
-                ->data('ObjectName', [
-                  'id' => 1
-                ]);
+            ->with()
+            ->translation('objectName', [
+                'localization_a' => ['Test'],
+            ])
+            ->and()
+            ->data('ObjectName', [
+                'id' => 1,
+            ]);
 
         $this->assertInstanceOf(EnqueueManager::class, $result);
     }
@@ -37,17 +35,13 @@ class EnqueueManagerTest extends TestCase
     public function testFluentApiChainingWithParametizedTranslation()
     {
         //Setup deps
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
         $manager->setDistDirectory('/path/to/dist');
 
         // Test chaining add and with('translation')->
-        $result = $manager
-            ->add('main.js', ['jquery'], '1.0.0', true)
-              ->with('translation', 'objectName', [
-                  'localization_a' => 'Test'
-              ]);
+        $result = $manager->add('main.js', ['jquery'], '1.0.0', true)->with('translation', 'objectName', [
+            'localization_a' => 'Test',
+        ]);
 
         $this->assertInstanceOf(EnqueueManager::class, $result);
     }
@@ -55,19 +49,19 @@ class EnqueueManagerTest extends TestCase
     public function testComplexFluentApiChainingWithParametizedTranslation()
     {
         //Setup deps
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
         $manager->setDistDirectory('/path/to/dist');
 
         // Test chaining add and with('translation')->
         $result = $manager
             ->add('main.js', ['jquery'], '1.0.0', true)
-              ->with('translation', 'objectName', [
-                  'localization_a' => 'Test'
-              ])->and()->data(null, [
-                  'id' => 1
-              ]);
+            ->with('translation', 'objectName', [
+                'localization_a' => 'Test',
+            ])
+            ->and()
+            ->data(null, [
+                'id' => 1,
+            ]);
 
         $this->assertInstanceOf(EnqueueManager::class, $result);
     }
@@ -75,65 +69,77 @@ class EnqueueManagerTest extends TestCase
     public function testComplexFluentApiChainingWithParametizedTranslationAndData()
     {
         //Setup deps
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
         $manager->setDistDirectory('/path/to/dist');
 
         // Test chaining add and with('translation')->
-        $result = $manager
-            ->add('main.js', ['jquery'], '1.0.0', true)
-              ->with('translation', 'objectName', [
-                  'localization_a' => 'Test'
-              ])->with('data', 'ObjectName', [
-                  'id' => 1
-              ])->with('data', 'ObjectName2', [
-                  'test' => 'value'
-              ]);
+        $result = $manager->add('main.js', ['jquery'], '1.0.0', true)->with('translation', 'objectName', [
+            'localization_a' => 'Test',
+        ])->with('data', 'ObjectName', [
+            'id' => 1,
+        ])->with('data', 'ObjectName2', [
+            'test' => 'value',
+        ]);
 
         $this->assertInstanceOf(EnqueueManager::class, $result);
     }
 
-    public function testComplexFluentApiChaining() {
-
+    public function testComplexFluentApiChaining()
+    {
         //Setup deps
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
         $manager->setDistDirectory('/path/to/dist');
 
         $result = $manager
             ->add('main.js', ['jquery'], '1.0.0', true)
-              ->with()->translation('objectName', [
-                'localization_a' => ['Test']
-              ])
+            ->with()
+            ->translation('objectName', [
+                'localization_a' => ['Test'],
+            ])
             ->add('second.js', [], '1.0.0', true)
-              ->with()->data(null, [
-                'id' => 1
-              ])
-              ->and()->translation('objectName2', [
-                'localization_b' => ['Test']
-              ])
+            ->with()
+            ->data(null, [
+                'id' => 1,
+            ])
+            ->and()
+            ->translation('objectName2', [
+                'localization_b' => ['Test'],
+            ])
             ->add('secondary.js');
 
         $this->assertInstanceOf(EnqueueManager::class, $result);
     }
 
-    public function testAndThrowsIfUsedBeforeWith() {
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+    public function testAndThrowsIfUsedBeforeWith()
+    {
+        $manager = new EnqueueManager($this->getWpService());
         $manager->setDistDirectory('/path/to/dist');
 
         $this->expectException(\RuntimeException::class);
         $manager->add('main.js', ['jquery'], '1.0.0', true)->and();
     }
 
+    public function testOnThrowsIfHooksIsInvalid()
+    {
+        $manager = new EnqueueManager($this->getWpService());
+        $manager->setDistDirectory('/path/to/dist');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $manager->add('main.js', ['jquery'], '1.0.0', true)->on('somehook', 20);
+    }
+
+    public function testOnThrowsIfNotUsedFirst()
+    {
+        $manager = new EnqueueManager($this->getWpService());
+        $manager->setDistDirectory('/path/to/dist');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $manager->add('main.js', ['jquery'], '1.0.0', true)->on('wp_enqueue_script', 20);
+    }
+
     public function testWithThrowsIfNoAssetAdded()
     {
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
 
         $this->expectException(\RuntimeException::class);
         $manager->with();
@@ -141,9 +147,7 @@ class EnqueueManagerTest extends TestCase
 
     public function testContextReturnsManager()
     {
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
 
         // Adds a main.js asset
         $manager->add('main.js');
@@ -159,21 +163,16 @@ class EnqueueManagerTest extends TestCase
 
     public function testThrowsIfObjectNameIsNotUnique()
     {
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
 
-        $manager->add('main.js')->with()->translation('objectName', ['key' => ['value']]) ;
+        $manager->add('main.js')->with()->translation('objectName', ['key' => ['value']]);
         $this->expectException(\RuntimeException::class);
         $manager->add('second.js')->with()->translation('objectName', ['key' => ['value']]);
     }
-    
 
     public function testThrowsIfTranslationIsAddedOnAssetWithoutAbility()
     {
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
 
         $manager->add('main.css');
         $this->expectException(\RuntimeException::class);
@@ -182,9 +181,7 @@ class EnqueueManagerTest extends TestCase
 
     public function testThrowsIfDataIsAddedOnAssetWithoutAbility()
     {
-        $manager = new EnqueueManager(
-            $this->getWpService()
-        );
+        $manager = new EnqueueManager($this->getWpService());
 
         $manager->add('main.css');
         $this->expectException(\RuntimeException::class);
@@ -206,14 +203,14 @@ class EnqueueManagerTest extends TestCase
         $callLogItem = $wpService->getCallLog('wpRegisterScript');
         $this->assertContains(
             [
-                'MainJs',
+                'mainjs',
                 'https://test.test/path/to/dist/main.js',
                 ['jquery'],
                 false,
                 true,
             ],
             $callLogItem,
-            'wpRegisterScript was not called with the expected arguments. Got:' . var_export($callLogItem, true)
+            'wpRegisterScript was not called with the expected arguments. Got:' . var_export($callLogItem, true),
         );
     }
 
@@ -232,13 +229,13 @@ class EnqueueManagerTest extends TestCase
         $callLogItem = $wpService->getCallLog('wpRegisterStyle');
         $this->assertContains(
             [
-                'MainCss',
+                'maincss',
                 'https://test.test/path/to/dist/main.css',
                 ['bootstrap'],
-                false
+                false,
             ],
             $callLogItem,
-            'wpRegisterStyle was not called with the expected arguments. Got:' . var_export($callLogItem, true)
+            'wpRegisterStyle was not called with the expected arguments. Got:' . var_export($callLogItem, true),
         );
     }
 
@@ -249,8 +246,6 @@ class EnqueueManagerTest extends TestCase
      */
     private function getWpService(): FakeWpService
     {
-        return new FakeWpService(
-            new HandlingFakeWpService()
-        );
+        return new FakeWpService(new HandlingFakeWpService());
     }
 }

--- a/tests/FakeWpService.php
+++ b/tests/FakeWpService.php
@@ -103,6 +103,11 @@ class FakeWpService extends BaseFakeWpService
         return true;
     }
 
+    public function wpJsonEncode(mixed $value, int $flags = 0, int $depth = 512): string
+    {
+        return json_encode($value, $flags, $depth);
+    }
+
     public function wpRegisterStyle(
         string $handle,
         string|false $src,

--- a/tests/FakeWpService.php
+++ b/tests/FakeWpService.php
@@ -1,9 +1,9 @@
-<?php 
+<?php
 
 namespace WpUtilService\Tests;
 
-use WpService\WpService;
 use WpService\Implementations\FakeWpService as BaseFakeWpService;
+use WpService\WpService;
 
 class FakeWpService extends BaseFakeWpService
 {
@@ -13,7 +13,10 @@ class FakeWpService extends BaseFakeWpService
     public array $localizedScripts = [];
     public array $filters = [];
 
-    public function __construct(private $innerService, private array $methods = []) {}
+    public function __construct(
+        private $innerService,
+        private array $methods = [],
+    ) {}
 
     /**
      * Magic method to handle dynamic method calls.
@@ -24,7 +27,7 @@ class FakeWpService extends BaseFakeWpService
         $this->logCall($name, $arguments);
 
         if (isset($this->methods[$name])) {
-            return ($this->methods[$name])(...$arguments);
+            return $this->methods[$name](...$arguments);
         }
 
         if (method_exists($this->innerService, $name)) {
@@ -54,7 +57,7 @@ class FakeWpService extends BaseFakeWpService
         string|false $src,
         array $deps = [],
         string|bool|null $ver = false,
-        array|bool $args = []
+        array|bool $args = [],
     ): bool {
         $this->logCall('wpRegisterScript', func_get_args());
         $this->registeredScripts[$handle] = [
@@ -77,7 +80,7 @@ class FakeWpService extends BaseFakeWpService
         return '/path/to/template';
     }
 
-    public function getSiteUrl(?int $blogId = null, string $path = '', ?string $scheme = null): string
+    public function getSiteUrl(null|int $blogId = null, string $path = '', null|string $scheme = null): string
     {
         return 'https://test.test/';
     }
@@ -88,14 +91,25 @@ class FakeWpService extends BaseFakeWpService
         return true;
     }
 
+    public function addAction(string $hookName, callable $callback, int $priority = 10, int $acceptedArgs = 1): true
+    {
+        $this->logCall('addAction', func_get_args());
+        return true;
+    }
+
     public function wpLocalizeScript(string $handle, string $objectName, array $data): bool
     {
         $this->logCall('wpLocalizeScript', func_get_args());
         return true;
     }
 
-    public function wpRegisterStyle(string $handle, string|false $src, array $deps = [], string|bool|null $ver = false, string $media = 'all'): bool
-    {
+    public function wpRegisterStyle(
+        string $handle,
+        string|false $src,
+        array $deps = [],
+        string|bool|null $ver = false,
+        string $media = 'all',
+    ): bool {
         $this->logCall('wpRegisterStyle', func_get_args());
         return true;
     }


### PR DESCRIPTION
This pull request adds support for specifying WordPress hooks and priorities when enqueuing assets, improving flexibility for asset management in the plugin. It introduces new methods to set and validate enqueue hooks, updates the fluent API for asset registration, and expands test coverage to ensure correct behavior for hook-based asset enqueuing.

### Enqueue Hook Support

* Added `setEnqueueHook` method to `AssetRegistrar`, allowing assets to be enqueued on specific WordPress hooks with validation for allowed hooks and priorities. (`src/Features/Enqueue/AssetRegistrar.php`)
* Updated asset registration logic to wrap enqueue functions so they can be conditionally attached to hooks via the new hook and priority properties. (`src/Features/Enqueue/AssetRegistrar.php`)

### Fluent API Enhancements

* Added `setEnqueueHook` and `on` methods to `EnqueueManager`, enabling fluent specification of hooks and priorities for asset chains. (`src/Features/Enqueue/EnqueueManager.php`) [[1]](diffhunk://#diff-d11d59d5fada41803a1a25ce5df680f285b99d57183713fadb2a4d23d1869065R91-R99) [[2]](diffhunk://#diff-d11d59d5fada41803a1a25ce5df680f285b99d57183713fadb2a4d23d1869065R190-R200)
* Updated documentation and usage examples to demonstrate new `on()` method in the fluent API. (`src/Traits/Enqueue.php`)

### Test Coverage and Robustness

* Added tests for hook validation, correct hook attachment, and isolation between chained asset registrations using hooks. (`tests/EnqueueManagerTest.php`)
* Improved test code formatting, normalization, and added assertions for asset registration correctness. (`tests/EnqueueManagerTest.php`) [[1]](diffhunk://#diff-d83f84868f12a7d2293fe5047cc26cd8ffa71e9286475b6ad50db713a4fc948fL209-R265) [[2]](diffhunk://#diff-d83f84868f12a7d2293fe5047cc26cd8ffa71e9286475b6ad50db713a4fc948fL235-R290)

### Minor Improvements

* Fixed nullable handling in `AssetUrlResolver::getDistDirectory` for safer path resolution. (`src/Features/Enqueue/AssetUrlResolver.php`)
* Updated visibility for `assetRegistrar` in `EnqueueManager` to allow direct access. (`src/Features/Enqueue/EnqueueManager.php`)

### Tooling

* Added a new `test:watch` script to `composer.json` for easier test-driven development. (`composer.json`)